### PR TITLE
need to quote strings for ini_set()

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -57,7 +57,7 @@ class Compiler
           $settings .= "$setting;";
         }
         foreach ($this->config['ini'] as $iniDirective => $iniValue) {
-            $settings .= "ini_set($iniDirective, $iniValue);";
+            $settings .= "ini_set('$iniDirective', '$iniValue');";
         }
         foreach ($this->config['include'] as $type => $includes) {
             foreach ($includes as $includePath) {


### PR DESCRIPTION
Experienced the following errors when using the ini() array in the config.yml being compiled into settings.php:
`Parse error: syntax error, unexpected 'M' (T_STRING) in /var/www/sites/cmog.dev/cnf/settings.php on line 14`

my `config.yml` looks like:

```
    ini: {memory_limit: "256M"}
```

Which compiles to this and breaks:

```
    ini_set(memory_limit, 256M); 
```

So, rather than doing something silly like: 

```
    ini: {"'memory_limit'": "'256M'"}
```

I've patched the compiler to add single quotes to the `ini_set()` argument strings. Which will properly to:

```
    ini_set('memory_limit', '256M'); 
```
